### PR TITLE
Allow running sbom scraper from other directories

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,3 +1,2 @@
 cyclonedx.xsd
 spdx.xsd
-credentials


### PR DESCRIPTION
Problem:
The sbom scraper script only works if run in current working directory

Solution:
cd to SCRIPTDIR to run git commands and refer to all files by full path

Signed-off-by: John Hartley