### PR TITLE
V0.4.0 errored on uploading cdx file

### DIFF
--- a/scripts/sbom_scraper.sh
+++ b/scripts/sbom_scraper.sh
@@ -425,6 +425,8 @@ author = ET.SubElement(authors, 'author')
 ET.SubElement(author, 'name').text = '$AUTHOR_NAME'
 ET.SubElement(author, 'email').text = '$AUTHOR_EMAIL'
 
+component = metadata.find('component', ns)
+
 # Update component publisher and author
 publisher = component.find('publisher', ns)
 if not publisher:
@@ -436,8 +438,6 @@ if not author:
     author = ET.Element('author')
     component.insert(0, author)
 author.text = '$COMPONENT_AUTHOR_NAME'
-
-component = metadata.find('component', ns)
 
 # Update component name and version
 component.find('name', ns).text = '$COMPONENT_NAME'
@@ -472,7 +472,7 @@ ET.SubElement(supplier, 'url').text = '$SUPPLIER_URL'
 indent(root)
 et.write(sys.stdout, encoding='unicode', xml_declaration=True, default_namespace='')
 END
-)
+) < "$OUTPUT" > "$PATCHED_OUTPUT"
 fi
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
Problem:
Uploading cdx file caused an error - no element found.

Solution:
There were 2 mistakes:
    1. the redirect from the input file to the patched output
       files had been deleted. Added back redirection.
    2. The embedded python refenced component.find() when component
       had not been yet created. Moved the component definition
       to earlier in the python code.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>