### PR TITLE
Docker image is too big.

### DIFF
--- a/Dockerfile-scraper
+++ b/Dockerfile-scraper
@@ -2,7 +2,7 @@ FROM ubuntu:jammy
 
 RUN apt-get update \
   && apt-get upgrade -y --no-install-recommends \
-  && apt-get install -y \
+  && apt-get install -y --no-install-recommends \
         curl \
         default-jdk \
         jq \


### PR DESCRIPTION
Problem:
Docker image is 1.18GB.

Solution:
Base ubuntu image is only 77.8MB so adding all deps adds 950MB. Added no-install-recommends reduces image size to 853MB.

Signed-off-by: Paul Hewlett <phewlett76@gmail.com>